### PR TITLE
Fix ASCII art and simplify profile to minimal design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,24 @@
-# DevDumpling's Daily Profile
+# Hi, I'm Dev(on) 👋
 
-_Generated on 2025-06-21_
-
-## I'm a Dad, a software dev, and a... well, Dev!
-
-```ts
-const dev = {
-  pronouns: ["they", "them", "he", "him"],
-  currentRole: "Principal Engineer @ Amino",
-  hobbies: ["Fantasy Books", "RPGs", "Bouldering"],
-};
 ```
 
-🚀 nurturing web architecture
-🌳 doing the dad thing
+ _____             
+|  _  \ _____   __
+| | | |/ _ \ \ / /
+| |_| |  __/\ V / 
+|_____/ \___| \_/  
+```
+
+Principal Engineer @ Amino • Dad • Developer
+
+🚀 nurturing web architecture  
+🌳 doing the dad thing  
 📖 staying curious
-
-```
-
-╔══════════════════════════════════════╗
-║     🚀 Coding Adventures Daily 🚀    ║
-║        Fresh Code, Fresh Ideas       ║
-╚══════════════════════════════════════╝
-```
-
-## 💭 Today's Quote
-
-> Debugging is twice as hard as writing the code in the first place. — Brian Kernighan
-
-## Tech I like
 
 > The best error message is the one that never shows up. — Thomas Fuchs
 
-## 🛠️ What I'm Working On
-
-- Building cool projects with TypeScript and modern web tech
-- Exploring new development patterns and best practices
-- Contributing to open source when possible
-
-## 📊 GitHub Stats
-
-- [Astro](https://astro.build/)
-- [Qwik, QwikCity](https://qwik.dev/)
-- [Fresh, Preact](https://fresh.deno.dev/)
-- [Solid](https://www.solidjs.com/)
-- [rwsdk](https://rwsdk.com/)
-- [Nuxt](https://nuxt.com/)
-- [Enhance](https://enhance.dev/)
-- [FAST](https://fast.design/)
-- [React, Next](https://nextjs.org/)
-
-_This section will be populated with recent GitHub activity_
-
 ---
 
-## 📊 GitHub Stats
+![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=creative)
 
-![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=minimal)
-
-## Influences
-
-- [John Cleese: A cheerful guide to creativity](https://www.designbetter.co/podcast/john-cleese)
-- [Cal Newport: Deep Work](https://www.shortform.com/summary/deep-work-summary-cal-newport)
-- [James Clear: Atomic Habits](https://www.quickread.com/book-summary/atomic-habits-97)
-- [Bret Victor - Inventing on Principle](https://www.youtube.com/watch?v=PUv66718DII)
-- [Alex Russell - All of his blog posts](https://infrequently.org/)
-- [Oliver Burkeman: Four Thousand Weeks](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122)
-
----
-
-_This profile is automatically updated daily. Last update: 2025-06-21_
+*Auto-updated daily • 2025-06-21*

--- a/history/2025-06-21.md
+++ b/history/2025-06-21.md
@@ -1,75 +1,24 @@
 # Hi, I'm Dev(on) 👋
 
-_Generated on 2025-06-21_
-
-## I'm a Dad, a software dev, and a... well, Dev!
-
-```ts
-const dev = {
-  pronouns: ["they", "them", "he", "him"],
-  currentRole: "Principal Engineer @ Amino",
-  hobbies: ["Fantasy Books", "RPGs", "Bouldering"],
-};
 ```
 
-🚀 nurturing web architecture
-🌳 doing the dad thing
+ _____             
+|  _  \ _____   __
+| | | |/ _ \ \ / /
+| |_| |  __/\ V / 
+|_____/ \___| \_/  
+```
+
+Principal Engineer @ Amino • Dad • Developer
+
+🚀 nurturing web architecture  
+🌳 doing the dad thing  
 📖 staying curious
 
-```
-
-╔══════════════════════════════════════╗
-║     🚀 Coding Adventures Daily 🚀    ║
-║        Fresh Code, Fresh Ideas       ║
-╚══════════════════════════════════════╝
-```
-
-## 💭 Today's Quote
-
-> Debugging is twice as hard as writing the code in the first place. — Brian Kernighan
-
-## Tech I like
-
-### `langs`
-
-- JS/TS
-- Rust
-- Go
-
-### `frameworks`
-
-> Lately I'm inspired by [Alex Russell's blog](https://infrequently.org/2024/01/performance-inequality-gap-2024/#the-budget%2C-2024) and am indulging myself in lighter-weight alternatives to React and Next, especially for primarily content-driven apps. Here are some of the frameworks I'm inspired by:
-
-- [Astro](https://astro.build/)
-- [Qwik, QwikCity](https://qwik.dev/)
-- [Fresh, Preact](https://fresh.deno.dev/)
-- [Solid](https://www.solidjs.com/)
-- [rwsdk](https://rwsdk.com/)
-- [Nuxt](https://nuxt.com/)
-- [Enhance](https://enhance.dev/)
-- [FAST](https://fast.design/)
-- [React, Next](https://nextjs.org/)
-
-### `tools`
-
-- [Deno](https://deno.com/)
-- [vite](https://vite.dev/)
-- [node](https://nodejs.org/)
-- [turborepo](https://turbo.build/repo/docs)
-
-## 📊 GitHub Stats
-
-![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=minimal)
-
-## Influences
-
-- [John Cleese: A cheerful guide to creativity](https://www.designbetter.co/podcast/john-cleese)
-- [Cal Newport: Deep Work](https://www.shortform.com/summary/deep-work-summary-cal-newport)
-- [James Clear: Atomic Habits](https://www.quickread.com/book-summary/atomic-habits-97)
-- [Bret Victor - Inventing on Principle](https://www.youtube.com/watch?v=PUv66718DII)
-- [Alex Russell - All of his blog posts](https://infrequently.org/)
-- [Oliver Burkeman: Four Thousand Weeks](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122)
+> The best error message is the one that never shows up. — Thomas Fuchs
 
 ---
 
-_This profile is automatically updated daily. Last update: 2025-06-21_
+![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=creative)
+
+*Auto-updated daily • 2025-06-21*

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -22,22 +22,17 @@ function getCurrentDate(): string {
 function generateASCIIArt(): string {
   const asciiArts = [
     `
-╭─────────────────────────────────────╮
-│  Welcome to DevDumpling's Profile!  │
-│           🥟 Daily Fresh 🥟         │
-╰─────────────────────────────────────╯`,
+┌────────────────────────────────┐
+│    dev(on) • daily fresh 🥟    │
+└────────────────────────────────┘`,
     `
-    ___                ___                     
-   /   \\   _____   __/   \\ _   _ _ __ ___  _ __
-  / /\\ / / _ \\ \\ / /\\ /\\ /| | | | '_ \` _ \\| '_ \\
- / /_/ /|  __/\\ V / /_/ / | |_| | | | | | | |_) |
-/___,'   \\___| \\_/ ___,'   \\__,_|_| |_| |_| .__/
-                                          |_|   `,
+ _____             
+|  _  \\ _____   __
+| | | |/ _ \\ \\ / /
+| |_| |  __/\\ V / 
+|_____/ \\___| \\_/  `,
     `
-╔══════════════════════════════════════╗
-║     🚀 Coding Adventures Daily 🚀    ║
-║        Fresh Code, Fresh Ideas       ║
-╚══════════════════════════════════════╝`
+[ dev • dad • dumpling ]`
   ];
   
   return asciiArts[Math.floor(Math.random() * asciiArts.length)];
@@ -74,75 +69,23 @@ function generateProfileContent(): ProfileContent {
 function createMarkdown(content: ProfileContent): string {
   return `# Hi, I'm Dev(on) 👋
 
-*Generated on ${content.date}*
-
-## I'm a Dad, a software dev, and a... well, Dev!
-
-\`\`\`ts
-const dev = {
-  pronouns: ["they", "them", "he", "him"],
-  currentRole: "Principal Engineer @ Amino",
-  hobbies: ["Fantasy Books", "RPGs", "Bouldering"],
-};
 \`\`\`
+${content.ascii}
+\`\`\`
+
+Principal Engineer @ Amino • Dad • Developer
 
 🚀 nurturing web architecture  
 🌳 doing the dad thing  
 📖 staying curious
 
-\`\`\`
-${content.ascii}
-\`\`\`
-
-## 💭 Today's Quote
-
 > ${content.quote}
-
-## Tech I like
-
-### \`langs\`
-
-- JS/TS
-- Rust
-- Go
-
-### \`frameworks\`
-
-> Lately I'm inspired by [Alex Russell's blog](https://infrequently.org/2024/01/performance-inequality-gap-2024/#the-budget%2C-2024) and am indulging myself in lighter-weight alternatives to React and Next, especially for primarily content-driven apps. Here are some of the frameworks I'm inspired by:
-
-- [Astro](https://astro.build/)
-- [Qwik, QwikCity](https://qwik.dev/)
-- [Fresh, Preact](https://fresh.deno.dev/)
-- [Solid](https://www.solidjs.com/)
-- [rwsdk](https://rwsdk.com/)
-- [Nuxt](https://nuxt.com/)
-- [Enhance](https://enhance.dev/)
-- [FAST](https://fast.design/)
-- [React, Next](https://nextjs.org/)
-
-### \`tools\`
-
-- [Deno](https://deno.com/)
-- [vite](https://vite.dev/)
-- [node](https://nodejs.org/)
-- [turborepo](https://turbo.build/repo/docs)
-
-## 📊 GitHub Stats
-
-![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=${content.theme})
-
-## Influences
-
-- [John Cleese: A cheerful guide to creativity](https://www.designbetter.co/podcast/john-cleese)
-- [Cal Newport: Deep Work](https://www.shortform.com/summary/deep-work-summary-cal-newport)
-- [James Clear: Atomic Habits](https://www.quickread.com/book-summary/atomic-habits-97)
-- [Bret Victor - Inventing on Principle](https://www.youtube.com/watch?v=PUv66718DII)
-- [Alex Russell - All of his blog posts](https://infrequently.org/)
-- [Oliver Burkeman: Four Thousand Weeks](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122)
 
 ---
 
-*This profile is automatically updated daily. Last update: ${content.date}*
+![Dev's GitHub stats](https://github-readme-stats.vercel.app/api?username=devdumpling&show_icons=true&theme=${content.theme})
+
+*Auto-updated daily • ${content.date}*
 `;
 }
 


### PR DESCRIPTION
## Summary
- Fixed ASCII art rendering issues with cleaner, simpler designs
- Removed verbose "Tech I like" section as requested  
- Streamlined profile to essential information only
- More professional and less "cringy" presentation

## Changes
- **ASCII Art**: Replaced problematic ASCII with simpler designs that render correctly
- **Content Reduction**: Removed entire tech stack sections for cleaner look
- **Layout**: Simplified to: header + ASCII + role + quote + GitHub stats
- **Tone**: More professional, less verbose

## Before/After
**Before**: Complex profile with multiple sections, rendering issues  
**After**: Clean, minimal profile focused on essential info

## Test plan
- [x] Generated profile locally with new minimal structure
- [x] Verified ASCII art renders correctly without cutting off
- [x] Confirmed all sections display properly
- [x] Maintained daily dynamic generation

🤖 Generated with Claude Code